### PR TITLE
internals: avoid crash when ES bulk returns NoOp status

### DIFF
--- a/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
@@ -1452,6 +1452,7 @@ pub struct InsertStats {
     pub(crate) created: usize,
     pub(crate) updated: usize,
     pub(crate) skipped: usize,
+    pub(crate) deleted: usize,
 }
 
 impl std::ops::Add for InsertStats {
@@ -1462,6 +1463,7 @@ impl std::ops::Add for InsertStats {
             created: self.created + rhs.created,
             updated: self.updated + rhs.updated,
             skipped: self.skipped + rhs.skipped,
+            deleted: self.deleted + rhs.deleted,
         }
     }
 }
@@ -1472,12 +1474,14 @@ impl From<InsertStats> for ModelInsertStats {
             created,
             updated,
             skipped,
+            deleted,
         } = stats;
 
         ModelInsertStats {
             created,
             updated,
             skipped,
+            deleted,
         }
     }
 }

--- a/libs/mimir/src/adapters/secondary/elasticsearch/models.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/models.rs
@@ -95,6 +95,7 @@ pub enum ElasticsearchBulkResult {
     Created,
     Updated,
     Deleted,
+    NoOp,
 }
 
 #[derive(Debug, Eq, PartialEq, Deserialize)]

--- a/libs/mimir/src/domain/model/stats.rs
+++ b/libs/mimir/src/domain/model/stats.rs
@@ -2,4 +2,5 @@
 pub struct InsertStats {
     pub created: usize,
     pub updated: usize,
+    pub skipped: usize,
 }

--- a/libs/mimir/src/domain/model/stats.rs
+++ b/libs/mimir/src/domain/model/stats.rs
@@ -3,4 +3,5 @@ pub struct InsertStats {
     pub created: usize,
     pub updated: usize,
     pub skipped: usize,
+    pub deleted: usize,
 }


### PR DESCRIPTION
On some corner cases we can get the following error while updating documents:

```
thread 'main' panicked at 'Error inserting chunk: JSON Elasticsearch Deserialization Error: error decoding response body: unknown variant `noop`, expected one of `created`, `updated
```