### PR TITLE
Print international labels

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -136,6 +136,7 @@ impl IntoAdmin for Zone {
             .and_then(|id| zones_osm_id.get(&id))
             .map(|(id, insee)| format_id(id, insee.as_ref()));
         let codes = osm_utils::get_osm_codes_from_tags(&self.tags);
+        println!("{:?}", self.international_labels);
         let mut admin = Admin {
             id: zones_osm_id
                 .get(&self.id)

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -137,6 +137,9 @@ impl IntoAdmin for Zone {
             .map(|(id, insee)| format_id(id, insee.as_ref()));
         let codes = osm_utils::get_osm_codes_from_tags(&self.tags);
         println!("{:?}", self.international_labels);
+        println!("{:?}", self.tags);
+        println!("aaaaaaaaaaaaaa");
+        println!("{:?}", self.international_names);
         let mut admin = Admin {
             id: zones_osm_id
                 .get(&self.id)

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -93,7 +93,7 @@ async fn run(
     }
 
     tracing::info!("Indexing cosmogony from {:?}", &opts.input);
-
+    println!("{:?}", settings.langs);
     mimirsbrunn::admin::index_cosmogony(
         &opts.input,
         settings.langs,


### PR DESCRIPTION
Print international labels in order to debug why international labels are missing