### PR TITLE
Add search endpoint

### DIFF
--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -8,13 +8,14 @@ use tracing::instrument;
 use warp::{
     http::StatusCode,
     reject::Reject,
-    Rejection,
     reply::{json, with_status},
+    Rejection,
 };
 
 use common::document::ContainerDocument;
-use places::{addr::Addr, admin::Admin, Place, poi::Poi, stop::Stop, street::Street};
+use places::{addr::Addr, admin::Admin, poi::Poi, stop::Stop, street::Street, Place};
 
+use crate::adapters::primary::common::filters::Filters;
 use crate::{
     adapters::{
         primary::{
@@ -47,7 +48,6 @@ use crate::{
     },
     utils::deserialize::deserialize_duration,
 };
-use crate::adapters::primary::common::filters::Filters;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/src/bragi/server.rs
+++ b/src/bragi/server.rs
@@ -93,7 +93,7 @@ pub async fn run_server(settings: Settings) -> Result<(), Error> {
             .map(ctx_builder())
             .and(routes::validate_query())
             .and(warp::any().map(|| None)) // the shape is None
-            .and_then(handlers::forward_geocoder)
+            .and_then(handlers::forward_autocomplete_geocoder)
     }
     .or({
         warp::post()
@@ -101,7 +101,15 @@ pub async fn run_server(settings: Settings) -> Result<(), Error> {
             .map(ctx_builder())
             .and(routes::validate_query())
             .and(routes::validate_geojson_body())
-            .and_then(handlers::forward_geocoder)
+            .and_then(handlers::forward_autocomplete_geocoder)
+    })
+    .or({
+        warp::get()
+            .and(path!("api" / "v1" / "search"))
+            .map(ctx_builder())
+            .and(routes::validate_query())
+            .and(warp::any().map(|| None)) // the shape is None
+            .and_then(handlers::forward_search_geocoder)
     })
     .or({
         warp::get()


### PR DESCRIPTION
Re-implement a `search` endpoint to get result directly from a final query sentence instead of calling `autocomplete` endpoint for a complete query