### PR TITLE
add a parameter to not connect to docker during tests

### DIFF
--- a/config/docker/default.toml
+++ b/config/docker/default.toml
@@ -1,4 +1,9 @@
 [docker]
+    # By default mimirsbrunn's test suite will connect to local docker host and
+    # start an elasticsearch pod by itself. You can disable this option to use
+    # an existing Elasticsearch instance.
+    enable = true
+
 	# Timeout for calls to docker engine (ms)
 	timeout = 5000
 
@@ -28,4 +33,3 @@
 	[docker.version]
     major = 1
     minor = 24
-

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -153,6 +153,7 @@ mod tests {
         docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
+
         let opts = settings::Opts {
             config_dir: [env!("CARGO_MANIFEST_DIR"), "config"].iter().collect(),
             run_mode: Some("testing".to_string()),
@@ -185,6 +186,7 @@ mod tests {
             langs: vec!["fr".to_string()],
             cosmogony_file,
         });
+
         let _res = mimirsbrunn::utils::launch::launch_async(move || run(opts, settings)).await;
         assert!(_res.is_ok());
 

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -171,10 +171,7 @@ mod tests {
 
         let settings = settings::Settings::new(&opts).unwrap();
         let res = mimirsbrunn::utils::launch::launch_async(move || run(opts, settings)).await;
-        assert!(res
-            .unwrap_err()
-            .to_string()
-            .contains("Connection Error"));
+        assert!(res.unwrap_err().to_string().contains("Connection Error"));
     }
 
     #[tokio::test]

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -171,9 +171,9 @@ mod tests {
 
         let settings = settings::Settings::new(&opts).unwrap();
         let res = mimirsbrunn::utils::launch::launch_async(move || run(opts, settings)).await;
-        assert!(res
+        assert!(dbg!(res
             .unwrap_err()
-            .to_string()
+            .to_string())
             .contains("Elasticsearch Connection Error"));
     }
 

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -171,10 +171,10 @@ mod tests {
 
         let settings = settings::Settings::new(&opts).unwrap();
         let res = mimirsbrunn::utils::launch::launch_async(move || run(opts, settings)).await;
-        assert!(dbg!(res
+        assert!(res
             .unwrap_err()
-            .to_string())
-            .contains("Elasticsearch Connection Error"));
+            .to_string()
+            .contains("Connection Error"));
     }
 
     #[tokio::test]

--- a/src/settings/bano2mimir.rs
+++ b/src/settings/bano2mimir.rs
@@ -97,11 +97,19 @@ pub enum Command {
 impl Settings {
     // Read the configuration from <config-dir>/bano2mimir and <config-dir>/elasticsearch
     pub fn new(opts: &Opts) -> Result<Self, Error> {
+        let prefix = {
+            if opts.run_mode.as_deref() == Some("testing") {
+                "MIMIR_TEST"
+            } else {
+                "MIMIR"
+            }
+        };
+
         common::config::config_from(
             opts.config_dir.as_ref(),
             &["bano2mimir", "elasticsearch"],
             opts.run_mode.as_deref(),
-            "MIMIR",
+            prefix,
             opts.settings.clone(),
         )
         .context(ConfigCompilationSnafu)?
@@ -159,6 +167,7 @@ mod tests {
     fn should_override_elasticsearch_url_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
         std::env::set_var("MIMIR_ELASTICSEARCH__URL", "http://localhost:9999");
+
         let opts = Opts {
             config_dir,
             run_mode: None,

--- a/src/settings/cosmogony2mimir.rs
+++ b/src/settings/cosmogony2mimir.rs
@@ -84,7 +84,6 @@ impl Settings {
             if opts.run_mode.as_deref() == Some("testing") {
                 "MIMIR_TEST"
             } else {
-                println!("helo");
                 "MIMIR"
             }
         };

--- a/src/settings/cosmogony2mimir.rs
+++ b/src/settings/cosmogony2mimir.rs
@@ -80,11 +80,20 @@ pub enum Command {
 impl Settings {
     // Read the configuration from <config-dir>/cosmogony2mimir and <config-dir>/elasticsearch
     pub fn new(opts: &Opts) -> Result<Self, Error> {
+        let prefix = {
+            if opts.run_mode.as_deref() == Some("testing") {
+                "MIMIR_TEST"
+            } else {
+                println!("helo");
+                "MIMIR"
+            }
+        };
+
         common::config::config_from(
             opts.config_dir.as_ref(),
             &["cosmogony2mimir", "elasticsearch"],
             opts.run_mode.as_deref(),
-            "MIMIR",
+            prefix,
             opts.settings.clone(),
         )
         .context(ConfigSourceSnafu)?

--- a/src/settings/ntfs2mimir.rs
+++ b/src/settings/ntfs2mimir.rs
@@ -89,11 +89,20 @@ pub enum Command {
 impl Settings {
     // Read the configuration from <config-dir>/ntfs2mimir and <config-dir>/elasticsearch
     pub fn new(opts: &Opts) -> Result<Self, Error> {
+        let prefix = {
+            if opts.run_mode.as_deref() == Some("testing") {
+                "MIMIR_TEST"
+            } else {
+                println!("helo");
+                "MIMIR"
+            }
+        };
+
         common::config::config_from(
             opts.config_dir.as_ref(),
             &["ntfs2mimir", "elasticsearch"],
             opts.run_mode.as_deref(),
-            "MIMIR",
+            prefix,
             opts.settings.clone(),
         )
         .context(ConfigSourceSnafu)?

--- a/src/settings/ntfs2mimir.rs
+++ b/src/settings/ntfs2mimir.rs
@@ -93,7 +93,6 @@ impl Settings {
             if opts.run_mode.as_deref() == Some("testing") {
                 "MIMIR_TEST"
             } else {
-                println!("helo");
                 "MIMIR"
             }
         };

--- a/src/settings/openaddresses2mimir.rs
+++ b/src/settings/openaddresses2mimir.rs
@@ -102,11 +102,20 @@ pub enum Command {
 impl Settings {
     // Read the configuration from <config-dir>/openaddresses2mimir and <config-dir>/elasticsearch
     pub fn new(opts: &Opts) -> Result<Self, Error> {
+        let prefix = {
+            if opts.run_mode.as_deref() == Some("testing") {
+                "MIMIR_TEST"
+            } else {
+                println!("helo");
+                "MIMIR"
+            }
+        };
+
         common::config::config_from(
             opts.config_dir.as_ref(),
             &["openaddresses2mimir", "elasticsearch"],
             opts.run_mode.as_deref(),
-            "MIMIR",
+            prefix,
             opts.settings.clone(),
         )
         .context(ConfigCompilationSnafu)?

--- a/src/settings/openaddresses2mimir.rs
+++ b/src/settings/openaddresses2mimir.rs
@@ -106,7 +106,6 @@ impl Settings {
             if opts.run_mode.as_deref() == Some("testing") {
                 "MIMIR_TEST"
             } else {
-                println!("helo");
                 "MIMIR"
             }
         };

--- a/src/settings/osm2mimir.rs
+++ b/src/settings/osm2mimir.rs
@@ -115,11 +115,20 @@ pub enum Command {
 impl Settings {
     // Read the configuration from <config-dir>/osm2mimir and <config-dir>/elasticsearch
     pub fn new(opts: &Opts) -> Result<Self, Error> {
+        let prefix = {
+            if opts.run_mode.as_deref() == Some("testing") {
+                "MIMIR_TEST"
+            } else {
+                println!("helo");
+                "MIMIR"
+            }
+        };
+
         common::config::config_from(
             opts.config_dir.as_ref(),
             &["osm2mimir", "elasticsearch"],
             opts.run_mode.as_deref(),
-            "MIMIR",
+            prefix,
             opts.settings.clone(),
         )
         .context(ConfigCompilationSnafu)?

--- a/src/settings/osm2mimir.rs
+++ b/src/settings/osm2mimir.rs
@@ -119,7 +119,6 @@ impl Settings {
             if opts.run_mode.as_deref() == Some("testing") {
                 "MIMIR_TEST"
             } else {
-                println!("helo");
                 "MIMIR"
             }
         };

--- a/src/settings/poi2mimir.rs
+++ b/src/settings/poi2mimir.rs
@@ -96,11 +96,20 @@ pub enum Command {
 impl Settings {
     // Read the configuration from <config-dir>/osm2mimir and <config-dir>/elasticsearch
     pub fn new(opts: &Opts) -> Result<Self, Error> {
+        let prefix = {
+            if opts.run_mode.as_deref() == Some("testing") {
+                "MIMIR_TEST"
+            } else {
+                println!("helo");
+                "MIMIR"
+            }
+        };
+
         common::config::config_from(
             opts.config_dir.as_ref(),
             &["poi2mimir", "elasticsearch"],
             opts.run_mode.as_deref(),
-            "MIMIR",
+            prefix,
             opts.settings.clone(),
         )
         .context(ConfigCompilationSnafu)?

--- a/src/settings/poi2mimir.rs
+++ b/src/settings/poi2mimir.rs
@@ -100,7 +100,6 @@ impl Settings {
             if opts.run_mode.as_deref() == Some("testing") {
                 "MIMIR_TEST"
             } else {
-                println!("helo");
                 "MIMIR"
             }
         };

--- a/tests/steps/search.rs
+++ b/tests/steps/search.rs
@@ -207,6 +207,7 @@ impl Step for HasAdmin {
             .steps_for::<Search>()
             .next_back()
             .expect("the user must perform a search before checking results");
+
         let rank = search
             .results
             .clone()


### PR DESCRIPTION
This allows to specify `MIMIR_TEST_DOCKER__ENABLE=false` during tests to directly connect to an existing ES instance (which URL is specified through `MIMIR_TEST_ELASTICSEARCH__URL`) without attempting any operation with a docker instance.